### PR TITLE
Fixed SHA1 deprecation warning by using SHA256

### DIFF
--- a/battery.rb
+++ b/battery.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Battery < Formula
   homepage 'https://github.com/Goles/Battery'
   url 'https://github.com/Goles/Battery/archive/1.3.tar.gz'
-  sha1 '88e7f744e80796a23cd765f990d783c7cf4abba1'
+  sha256 'b724ff05fdcbb7e37e88432f9ae0f5235d5b22b1fd7c30d6973d91d27ac7a495'
   version '1.3'
 
   depends_on 'spark'


### PR DESCRIPTION
Simple formula edit to use SHA256 instead of deprecated SHA1.
