### PR TITLE
Allow HEAD install

### DIFF
--- a/battery.rb
+++ b/battery.rb
@@ -5,6 +5,7 @@ class Battery < Formula
   url 'https://github.com/Goles/Battery/archive/1.4.tar.gz'
   sha256 '99d95baa9532108fed518e4b01500a764ad59cb31611ce10c28138f28ebc3037'
   version '1.4'
+  head 'https://github.com/Goles/Battery.git'
 
   depends_on 'spark'
 


### PR DESCRIPTION
The most recent release is 1.3 which dates back to September 2013.

Some new features have been added and while they may not justify a 1.4 version, at least the current version on `HEAD` can be made available for users to easily install the latest features.